### PR TITLE
icd: Handle FSR sample count special case

### DIFF
--- a/icd/vksc_physical_device.h
+++ b/icd/vksc_physical_device.h
@@ -65,6 +65,9 @@ class PhysicalDevice : public Dispatchable<PhysicalDevice, VkPhysicalDevice>, pu
     VkResult GetPhysicalDeviceRefreshableObjectTypesKHR(uint32_t* pRefreshableObjectTypeCount,
                                                         VkObjectType* pRefreshableObjectTypes);
 
+    VkResult GetPhysicalDeviceFragmentShadingRatesKHR(uint32_t* pFragmentShadingRateCount,
+                                                      VkPhysicalDeviceFragmentShadingRateKHR* pFragmentShadingRates);
+
 #if defined(VK_USE_PLATFORM_WIN32_KHR)
     VkResult AcquireWinrtDisplayNV(VkDisplayKHR display);
 #endif


### PR DESCRIPTION
The spec requires ~0 to be returned in VkPhysicalDeviceFragmentShadingRateKHR::sampleCount when VkPhysicalDeviceFragmentShadingRateKHR::fragmentSize == {1, 1}, even though that is technically not a value comprising of valid, well defined bit flags, so we have to work this around here manually because the result sanitization logic will remove all the bits from flags that are not defined in in Vulkan SC API.