### PR TITLE
icd: Add emulated SubmitDebugUtilsMessageEXT

### DIFF
--- a/icd/icd_log.h
+++ b/icd/icd_log.h
@@ -72,6 +72,11 @@ class Logger {
 
     void RemoveDebugMessenger(VkDebugUtilsMessengerEXT handle) { messengers_->Remove(handle); }
 
+    void SubmitMessage(VkDebugUtilsMessageSeverityFlagBitsEXT severity, VkDebugUtilsMessageTypeFlagsEXT types,
+                       const VkDebugUtilsMessengerCallbackDataEXT& data) {
+        messengers_->Send(severity, types, data);
+    }
+
     template <typename... ARGS>
     void Fatal(const char* msg_id, const char* format, ARGS... args) const {
         Log(true, VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT, VK_DEBUG_UTILS_MESSAGE_TYPE_GENERAL_BIT_EXT, msg_id, format,

--- a/icd/vksc_command_buffer.cpp
+++ b/icd/vksc_command_buffer.cpp
@@ -7,6 +7,7 @@
 
 #include "vksc_command_buffer.h"
 #include "vksc_device.h"
+#include "vksc_global.h"
 
 namespace vksc {
 
@@ -35,6 +36,30 @@ VkResult CommandBuffer::EndCommandBuffer() {
         return GetStatus();
     } else {
         return NEXT::EndCommandBuffer();
+    }
+}
+
+void CommandBuffer::CmdBeginDebugUtilsLabelEXT(const VkDebugUtilsLabelEXT* pLabelInfo) {
+    // NOTE: We do not currently include debug util labels in our debug messages
+    if (ICD.IsInstanceExtensionSupported(vk::ExtensionNumber::EXT_debug_utils)) {
+        // Forward call to the underlying Vulkan implementation if it supports it
+        NEXT::CmdBeginDebugUtilsLabelEXT(pLabelInfo);
+    }
+}
+
+void CommandBuffer::CmdEndDebugUtilsLabelEXT() {
+    // NOTE: We do not currently include debug util labels in our debug messages
+    if (ICD.IsInstanceExtensionSupported(vk::ExtensionNumber::EXT_debug_utils)) {
+        // Forward call to the underlying Vulkan implementation if it supports it
+        NEXT::CmdEndDebugUtilsLabelEXT();
+    }
+}
+
+void CommandBuffer::CmdInsertDebugUtilsLabelEXT(const VkDebugUtilsLabelEXT* pLabelInfo) {
+    // NOTE: We do not currently include debug util labels in our debug messages
+    if (ICD.IsInstanceExtensionSupported(vk::ExtensionNumber::EXT_debug_utils)) {
+        // Forward call to the underlying Vulkan implementation if it supports it
+        NEXT::CmdInsertDebugUtilsLabelEXT(pLabelInfo);
     }
 }
 

--- a/icd/vksc_command_buffer.h
+++ b/icd/vksc_command_buffer.h
@@ -26,6 +26,10 @@ class CommandBuffer : public Dispatchable<CommandBuffer, VkCommandBuffer>, publi
     void CmdRefreshObjectsKHR(const VkRefreshObjectListKHR* pRefreshObjects);
     VkResult EndCommandBuffer();
 
+    void CmdBeginDebugUtilsLabelEXT(const VkDebugUtilsLabelEXT* pLabelInfo);
+    void CmdEndDebugUtilsLabelEXT();
+    void CmdInsertDebugUtilsLabelEXT(const VkDebugUtilsLabelEXT* pLabelInfo);
+
   private:
     icd::Logger logger_;
 };

--- a/icd/vksc_device.cpp
+++ b/icd/vksc_device.cpp
@@ -10,6 +10,7 @@
 #include "vksc_queue.h"
 #include "vksc_command_buffer.h"
 #include "vksc_instance.h"
+#include "vksc_global.h"
 #include "icd_proc_addr.h"
 #include "icd_pnext_chain_utils.h"
 
@@ -544,6 +545,24 @@ VkResult Device::CreateSharedSwapchainsKHR(uint32_t swapchainCount, const VkSwap
         // We ran out of requested query pool objects
         return VK_ERROR_OUT_OF_HOST_MEMORY;
     }
+}
+
+VkResult Device::SetDebugUtilsObjectNameEXT(const VkDebugUtilsObjectNameInfoEXT* pNameInfo) {
+    // NOTE: We do not currently include debug util object names in our debug messages
+    if (ICD.IsInstanceExtensionSupported(vk::ExtensionNumber::EXT_debug_utils)) {
+        // Forward call to the underlying Vulkan implementation if it supports it
+        return NEXT::SetDebugUtilsObjectNameEXT(pNameInfo);
+    }
+    return VK_SUCCESS;
+}
+
+VkResult Device::SetDebugUtilsObjectTagEXT(const VkDebugUtilsObjectTagInfoEXT* pTagInfo) {
+    // NOTE: We do not currently include debug util object tags in our debug messages
+    if (ICD.IsInstanceExtensionSupported(vk::ExtensionNumber::EXT_debug_utils)) {
+        // Forward call to the underlying Vulkan implementation if it supports it
+        return NEXT::SetDebugUtilsObjectTagEXT(pTagInfo);
+    }
+    return VK_SUCCESS;
 }
 
 }  // namespace vksc

--- a/icd/vksc_device.h
+++ b/icd/vksc_device.h
@@ -95,6 +95,9 @@ class Device : public Dispatchable<Device, VkDevice>, public vk::Device {
     VkResult CreateSharedSwapchainsKHR(uint32_t swapchainCount, const VkSwapchainCreateInfoKHR* pCreateInfos,
                                        const VkAllocationCallbacks* pAllocator, VkSwapchainKHR* pSwapchains);
 
+    VkResult SetDebugUtilsObjectNameEXT(const VkDebugUtilsObjectNameInfoEXT* pNameInfo);
+    VkResult SetDebugUtilsObjectTagEXT(const VkDebugUtilsObjectTagInfoEXT* pTagInfo);
+
   private:
     VkResult SetupDevice(const VkDeviceCreateInfo& create_info);
     const icd::Pipeline* GetPipelineFromCache(const icd::PipelineCache& pipeline_cache,

--- a/icd/vksc_instance.cpp
+++ b/icd/vksc_instance.cpp
@@ -207,6 +207,16 @@ void Instance::DestroyDebugUtilsMessengerEXT(VkDebugUtilsMessengerEXT messenger,
     }
 }
 
+void Instance::SubmitDebugUtilsMessageEXT(VkDebugUtilsMessageSeverityFlagBitsEXT messageSeverity,
+                                          VkDebugUtilsMessageTypeFlagsEXT messageTypes,
+                                          const VkDebugUtilsMessengerCallbackDataEXT* pCallbackData) {
+    if (ICD.IsInstanceExtensionEmulated(ExtensionNumber::EXT_debug_utils)) {
+        Log().SubmitMessage(messageSeverity, messageTypes, *pCallbackData);
+    } else {
+        NEXT::SubmitDebugUtilsMessageEXT(messageSeverity, messageTypes, pCallbackData);
+    }
+}
+
 VkResult Instance::CreateDisplayPlaneSurfaceKHR(const VkDisplaySurfaceCreateInfoKHR* pCreateInfo,
                                                 const VkAllocationCallbacks* pAllocator, VkSurfaceKHR* pSurface) {
     auto emulated_display_mode = GetDisplayManager().GetEmulatedDisplayModeFromHandle(pCreateInfo->displayMode);

--- a/icd/vksc_instance.h
+++ b/icd/vksc_instance.h
@@ -49,6 +49,9 @@ class Instance : public Dispatchable<Instance, VkInstance>, public vk::Instance 
     VkResult CreateDebugUtilsMessengerEXT(const VkDebugUtilsMessengerCreateInfoEXT* pCreateInfo,
                                           const VkAllocationCallbacks* pAllocator, VkDebugUtilsMessengerEXT* pMessenger);
     void DestroyDebugUtilsMessengerEXT(VkDebugUtilsMessengerEXT messenger, const VkAllocationCallbacks* pAllocator);
+    void SubmitDebugUtilsMessageEXT(VkDebugUtilsMessageSeverityFlagBitsEXT messageSeverity,
+                                    VkDebugUtilsMessageTypeFlagsEXT messageTypes,
+                                    const VkDebugUtilsMessengerCallbackDataEXT* pCallbackData);
 
     VkResult CreateDisplayPlaneSurfaceKHR(const VkDisplaySurfaceCreateInfoKHR* pCreateInfo, const VkAllocationCallbacks* pAllocator,
                                           VkSurfaceKHR* pSurface);

--- a/icd/vksc_queue.cpp
+++ b/icd/vksc_queue.cpp
@@ -8,6 +8,7 @@
 #include "vksc_queue.h"
 #include "vksc_device.h"
 #include "vksc_command_buffer.h"
+#include "vksc_global.h"
 
 namespace vksc {
 
@@ -49,6 +50,30 @@ VkResult Queue::QueueSubmit2KHR(uint32_t submitCount, const VkSubmitInfo2* pSubm
     }
 
     return NEXT::QueueSubmit2KHR(submitCount, submit_info, fence);
+}
+
+void Queue::QueueBeginDebugUtilsLabelEXT(const VkDebugUtilsLabelEXT* pLabelInfo) {
+    // NOTE: We do not currently include debug util labels in our debug messages
+    if (ICD.IsInstanceExtensionSupported(vk::ExtensionNumber::EXT_debug_utils)) {
+        // Forward call to the underlying Vulkan implementation if it supports it
+        NEXT::QueueBeginDebugUtilsLabelEXT(pLabelInfo);
+    }
+}
+
+void Queue::QueueEndDebugUtilsLabelEXT() {
+    // NOTE: We do not currently include debug util labels in our debug messages
+    if (ICD.IsInstanceExtensionSupported(vk::ExtensionNumber::EXT_debug_utils)) {
+        // Forward call to the underlying Vulkan implementation if it supports it
+        NEXT::QueueEndDebugUtilsLabelEXT();
+    }
+}
+
+void Queue::QueueInsertDebugUtilsLabelEXT(const VkDebugUtilsLabelEXT* pLabelInfo) {
+    // NOTE: We do not currently include debug util labels in our debug messages
+    if (ICD.IsInstanceExtensionSupported(vk::ExtensionNumber::EXT_debug_utils)) {
+        // Forward call to the underlying Vulkan implementation if it supports it
+        NEXT::QueueInsertDebugUtilsLabelEXT(pLabelInfo);
+    }
 }
 
 }  // namespace vksc

--- a/icd/vksc_queue.h
+++ b/icd/vksc_queue.h
@@ -29,6 +29,10 @@ class Queue : public Dispatchable<Queue, VkQueue>, public vk::Queue {
     VkResult QueueSubmit(uint32_t submitCount, const VkSubmitInfo* pSubmits, VkFence fence);
     VkResult QueueSubmit2KHR(uint32_t submitCount, const VkSubmitInfo2* pSubmits, VkFence fence);
 
+    void QueueBeginDebugUtilsLabelEXT(const VkDebugUtilsLabelEXT* pLabelInfo);
+    void QueueEndDebugUtilsLabelEXT();
+    void QueueInsertDebugUtilsLabelEXT(const VkDebugUtilsLabelEXT* pLabelInfo);
+
   private:
     icd::Logger logger_;
 };

--- a/tests/icd/test_infrastructure.cpp
+++ b/tests/icd/test_infrastructure.cpp
@@ -367,6 +367,12 @@ TEST_F(InfrastructureTest, DebugUtilsMessenger) {
               VK_ERROR_INVALID_PIPELINE_CACHE_DATA);
     EXPECT_EQ(callback_data.call_count, 0);
 
+    // Send a manual message (we still should receive no callbacks)
+    auto cb_data = vku::InitStruct<VkDebugUtilsMessengerCallbackDataEXT>();
+    vksc::SubmitDebugUtilsMessageEXT(instance, VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT,
+                                     VK_DEBUG_UTILS_MESSAGE_TYPE_GENERAL_BIT_EXT, &cb_data);
+    EXPECT_EQ(callback_data.call_count, 0);
+
     // Create an additional messenger
     if (Framework::WithVulkanLoader()) {
         // The Vulkan loader exposes support for VK_EXT_debug_utils so we need mocks
@@ -402,13 +408,18 @@ TEST_F(InfrastructureTest, DebugUtilsMessenger) {
               VK_ERROR_INVALID_PIPELINE_CACHE_DATA);
     EXPECT_EQ(callback_data.call_count, 4);
 
+    // We send a manual message forcing out another call
+    vksc::SubmitDebugUtilsMessageEXT(instance, VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT,
+                                     VK_DEBUG_UTILS_MESSAGE_TYPE_GENERAL_BIT_EXT, &cb_data);
+    EXPECT_EQ(callback_data.call_count, 5);
+
     // Destroy the second messenger
     vksc::DestroyDebugUtilsMessengerEXT(instance, messenger2, nullptr);
 
     // After deleting the additional messenger, once again, no calls are triggered
     EXPECT_EQ(vksc::CreatePipelineCache(device, &pipeline_cache_ci, nullptr, &pipeline_cache),
               VK_ERROR_INVALID_PIPELINE_CACHE_DATA);
-    EXPECT_EQ(callback_data.call_count, 4);
+    EXPECT_EQ(callback_data.call_count, 5);
 }
 
 TEST_F(InfrastructureTest, CreateDeviceStructChain) {


### PR DESCRIPTION
There are a set of other `VK_EXT_debug_utils` entry points that we could also emulate (e.g. attaching labels/names) in the future for complete support for the facilities of the debug utils extension.