### PR TITLE
Fix swapchain creation always failing

### DIFF
--- a/icd/vksc_device.cpp
+++ b/icd/vksc_device.cpp
@@ -1273,7 +1273,7 @@ bool Device::InitSwapchainImageInfo(VkSwapchainKHR swapchain, VkExtent2D extent,
     for (uint32_t i = 0; i < image_count; ++i) {
         images_.Add(images[i], VK_IMAGE_TYPE_2D, VkExtent3D{extent.width, extent.height, 1}, 1, array_layers);
     }
-    return false;
+    return true;
 }
 
 }  // namespace vksc


### PR DESCRIPTION
`InitSwapchainImageInfo` seems to always return false, resulting in `Device::CreateSwapchainKHR()` always failing with `VK_ERROR_INITIALIZATION_FAILED`. 

This was seen when using https://github.com/KhronosGroup/VulkanSC-Emulation/commit/41581abdadcc31b32eb4e49bb323975667a616db with the vksccube example on https://github.com/KhronosGroup/VulkanSC-Tools/commit/483d0dfa3f3cb772693ad825c39ac290b3b8df3f. 

The change is what I assume is supposed to be the success path. This got the vksccube example running.